### PR TITLE
More hud coloring

### DIFF
--- a/src/game/client/sf/teamcolorproxy.cpp
+++ b/src/game/client/sf/teamcolorproxy.cpp
@@ -40,7 +40,18 @@ public:
 
 protected:
 	virtual int			GetDisplayTeamNum(void* pC_BaseEntity);
+};
 
+class CEntityTeamColorProxyRed : public CEntityTeamColorProxy
+{
+protected:
+	virtual int			GetDisplayTeamNum(void* pC_BaseEntity){return TF_TEAM_RED;}
+};
+
+class CEntityTeamColorProxyBlue : public CEntityTeamColorProxy
+{
+protected:
+	virtual int			GetDisplayTeamNum(void* pC_BaseEntity){return TF_TEAM_BLUE;}
 };
 
 //-----------------------------------------------------------------------------
@@ -126,7 +137,7 @@ void CEntityTeamColorProxy::OnBind(void* pC_BaseEntity)
 {
 	int iTeamNum = GetDisplayTeamNum(pC_BaseEntity);
 
-	if (iTeamNum == -1)
+	if (iTeamNum == TEAM_INVALID)
 	{
 		Warning("OnBind Failed from a wrong team number %i\n", iTeamNum);
 		return;
@@ -137,17 +148,19 @@ void CEntityTeamColorProxy::OnBind(void* pC_BaseEntity)
 	switch (iTeamNum)
 	{
 	case TF_TEAM_RED:
-			if (!TFGameRules()) break;
+		if (!TFGameRules())
+			break;
 		color = TFGameRules()->GetRedTeamColor();
 		break;
 
 	case TF_TEAM_BLUE:
-			if (!TFGameRules()) break;
+		if (!TFGameRules())
+			break;
 		color = TFGameRules()->GetBlueTeamColor();
 		break;
 
 	case TEAM_UNASSIGNED:
-		default:
+	default:
 		int r, g, b;
 		r = g = b = 0;
 
@@ -156,11 +169,11 @@ void CEntityTeamColorProxy::OnBind(void* pC_BaseEntity)
 
 		if (scanned != 3)
 		{
-				color = Vector(0, 0, 0);
+			color = Vector(0, 0, 0);
 			break;
 		}
 
-			color = Vector(r, g, b);
+		color = Vector(r, g, b);
 		break;
 	}
 
@@ -173,3 +186,5 @@ void CEntityTeamColorProxy::OnBind(void* pC_BaseEntity)
 }
 
 EXPOSE_INTERFACE(CEntityTeamColorProxy, IMaterialProxy, "TeamColor" IMATERIAL_PROXY_INTERFACE_VERSION);
+EXPOSE_INTERFACE(CEntityTeamColorProxyRed, IMaterialProxy, "TeamColorRed" IMATERIAL_PROXY_INTERFACE_VERSION);
+EXPOSE_INTERFACE(CEntityTeamColorProxyBlue, IMaterialProxy, "TeamColorBlue" IMATERIAL_PROXY_INTERFACE_VERSION);

--- a/src/materialsystem/stdshaders/TeamColorHUD.cpp
+++ b/src/materialsystem/stdshaders/TeamColorHUD.cpp
@@ -63,11 +63,13 @@ SHADER_PARAM(ALPHATESTREFERENCE, SHADER_PARAM_TYPE_FLOAT, "", "")
 // Main Features here!
 SHADER_PARAM(BLENDTINTBYBASEALPHA, SHADER_PARAM_TYPE_BOOL, "", "")
 SHADER_PARAM(BLENDTINTCOLOROVERBASE, SHADER_PARAM_TYPE_FLOAT, "", "")
+SHADER_PARAM(REDCOLOR, SHADER_PARAM_TYPE_COLOR, "", "")
+SHADER_PARAM(BLUECOLOR, SHADER_PARAM_TYPE_COLOR, "", "")
 
-// For feeding a dedicated AlphaTexture
-// When using $BlendTintByBaseAlpha and $Detail, uses this for DistanceAlpha!
-SHADER_PARAM(ALPHATEXTURE, SHADER_PARAM_TYPE_TEXTURE, "", "")
-SHADER_PARAM(ALPHATEXTUREFRAME, SHADER_PARAM_TYPE_INTEGER, "", "")
+SHADER_PARAM(COLORMASK, SHADER_PARAM_TYPE_TEXTURE, "", "")
+SHADER_PARAM(COLORMASKFRAME, SHADER_PARAM_TYPE_INTEGER, "", "")
+
+
 END_SHADER_PARAMS
 
 	SHADER_INIT_PARAMS()
@@ -108,6 +110,9 @@ END_SHADER_PARAMS
 		if (!IsDefined(OUTLINEALPHA))
 			params[OUTLINEALPHA]->SetFloatValue(1.0f);
 
+		if (!IsDefined(COLORMASK))
+			params[COLORMASK]->SetStringValue("dev/black");
+
 		// Warnings!
 		// ========================= //
 		if (IsDefined(DETAILBLENDMODE))
@@ -143,8 +148,8 @@ END_SHADER_PARAMS
 				LoadTexture(DETAIL, TEXTUREFLAGS_SRGB);
 		}
 
-		if (IsDefined(ALPHATEXTURE))
-			LoadTexture(ALPHATEXTURE);
+		if (IsDefined(COLORMASK))
+			LoadTexture(COLORMASK);
 	}
 	
 	SHADER_FALLBACK
@@ -173,7 +178,7 @@ END_SHADER_PARAMS
 		// Textures
 		bool bHasBaseTexture = IsDefined(BASETEXTURE) && params[BASETEXTURE]->IsTexture();
 		bool bHasDetailTexture = IsDefined(DETAIL) && params[DETAIL]->IsTexture();
-		bool bHasAlphaTexture = IsDefined(ALPHATEXTURE) && params[ALPHATEXTURE]->IsTexture();
+		//bool bHasAlphaTexture = IsDefined(ALPHATEXTURE) && params[ALPHATEXTURE]->IsTexture();
 		bool bHasDistanceAlpha = params[DISTANCEALPHA]->GetIntValue() != 0;
 
 		// Need this for Static Combo, sRGBRead and BlendType
@@ -198,7 +203,7 @@ END_SHADER_PARAMS
 		nBlendType = EvaluateBlendRequirements(BASETEXTURE, true, nDetailTranslucencyTexture);
 
 		// If we have a $AlphaTexture, Translucent can be used ( BT_BLEND )
-		if (bHasAlphaTexture && IS_FLAG_SET(MATERIAL_VAR_TRANSLUCENT) && !IS_FLAG_SET(MATERIAL_VAR_ALPHATEST))
+		if (/*bHasAlphaTexture &&*/ IS_FLAG_SET(MATERIAL_VAR_TRANSLUCENT) && !IS_FLAG_SET(MATERIAL_VAR_ALPHATEST))
 			nBlendType = BT_BLEND;
 
 		bool bIsFullyOpaque = (nBlendType != BT_BLENDADD) && (nBlendType != BT_BLEND) && !bAlphaTest;
@@ -281,11 +286,11 @@ END_SHADER_PARAMS
 					pShaderShadow->EnableSRGBRead(SHADER_SAMPLER1, true);
 			}
 
-			if (bHasAlphaTexture)
-			{
+			// if (bHasAlphaTexture)
+			// {
 				// Never sRGB!! Linear Values!!!
 				pShaderShadow->EnableTexture(SHADER_SAMPLER2, true);
-			}
+			//}
 
 			bool bDistanceAlphaFromDetail = false;
 			bool bSoftMask = false;
@@ -340,7 +345,7 @@ END_SHADER_PARAMS
 			SET_STATIC_PIXEL_SHADER_COMBO(BLENDTINTBYXALPHA, bBlendTintByBaseAlpha);
 			SET_STATIC_PIXEL_SHADER_COMBO(VERTEXRGB, bHasVertexRGB);
 			SET_STATIC_PIXEL_SHADER_COMBO(VERTEXA, bHasVertexA);
-			SET_STATIC_PIXEL_SHADER_COMBO(ALPHATEXTURE, bHasAlphaTexture);
+			//SET_STATIC_PIXEL_SHADER_COMBO(ALPHATEXTURE, bHasAlphaTexture);
 			SET_STATIC_PIXEL_SHADER(teamcolorhud_ps20b);
 		}
 
@@ -391,8 +396,8 @@ END_SHADER_PARAMS
 			}
 
 			// s2
-			if (bHasAlphaTexture)
-				BindTexture(SHADER_SAMPLER2, ALPHATEXTURE, ALPHATEXTUREFRAME);
+			//if (bHasAlphaTexture)
+				BindTexture(SHADER_SAMPLER2, COLORMASK, COLORMASKFRAME);
 
 			if (bHasDistanceAlpha)
 			{
@@ -454,12 +459,18 @@ END_SHADER_PARAMS
 					flOutlineEnd1,
 					flOutlineEnd0,
 					flOutlineStart1,
+					// c10 - Red team color (filled in a second)
+					1, 0, 0, 1,
+					// c11 - Blue team color (filled in a second)
+					0, 0, 1, 1
 				};
 
 				params[GLOWCOLOR]->GetVecValue(flConsts + 4, 3);
 				params[OUTLINECOLOR]->GetVecValue(flConsts + 12, 3);
+				//params[REDCOLOR]->GetVecValue(flConsts + 20, 3);
+				//params[BLUECOLOR]->GetVecValue(flConsts + 24, 3);
 
-				pShaderAPI->SetPixelShaderConstant(5, flConsts, 5);
+				pShaderAPI->SetPixelShaderConstant(5, flConsts, 7);
 
 			}
 

--- a/src/materialsystem/stdshaders/TeamColorHUD.cpp
+++ b/src/materialsystem/stdshaders/TeamColorHUD.cpp
@@ -459,20 +459,27 @@ END_SHADER_PARAMS
 					flOutlineEnd1,
 					flOutlineEnd0,
 					flOutlineStart1,
-					// c10 - Red team color (filled in a second)
-					1, 0, 0, 1,
-					// c11 - Blue team color (filled in a second)
-					0, 0, 1, 1
 				};
 
 				params[GLOWCOLOR]->GetVecValue(flConsts + 4, 3);
 				params[OUTLINECOLOR]->GetVecValue(flConsts + 12, 3);
-				//params[REDCOLOR]->GetVecValue(flConsts + 20, 3);
-				//params[BLUECOLOR]->GetVecValue(flConsts + 24, 3);
 
-				pShaderAPI->SetPixelShaderConstant(5, flConsts, 7);
+				pShaderAPI->SetPixelShaderConstant(5, flConsts, 5);
 
 			}
+
+			float flColorConsts[] = {
+				// c10 Red team
+				0,0,0,0,
+				// c11 Blue Team
+				0,0,0,0
+			};
+
+			params[REDCOLOR]->GetVecValue(flColorConsts, 3);
+			params[BLUECOLOR]->GetVecValue(flColorConsts + 4, 3);
+
+			SetPixelShaderConstantGammaToLinear(10, flColorConsts, 2);
+
 
 			DECLARE_DYNAMIC_VERTEX_SHADER(teamcolorhud_vs20);
 			SET_DYNAMIC_VERTEX_SHADER_COMBO(SKINNING, pShaderAPI->GetCurrentNumBones() > 0);

--- a/src/materialsystem/stdshaders/include/teamcolorhud_ps20b.inc
+++ b/src/materialsystem/stdshaders/include/teamcolorhud_ps20b.inc
@@ -19,14 +19,12 @@ class teamcolorhud_ps20b_Static_Index
 	unsigned int m_nBLENDTINTBYXALPHA : 2;
 	unsigned int m_nVERTEXRGB : 2;
 	unsigned int m_nVERTEXA : 2;
-	unsigned int m_nALPHATEXTURE : 2;
 #ifdef _DEBUG
 	bool m_bDISTANCEALPHAMODE : 1;
 	bool m_bDETAILTEXTUREMODE : 1;
 	bool m_bBLENDTINTBYXALPHA : 1;
 	bool m_bVERTEXRGB : 1;
 	bool m_bVERTEXA : 1;
-	bool m_bALPHATEXTURE : 1;
 #endif	// _DEBUG
 public:
 	void SetDISTANCEALPHAMODE( int i )
@@ -74,15 +72,6 @@ public:
 #endif	// _DEBUG
 	}
 
-	void SetALPHATEXTURE( int i )
-	{
-		Assert( i >= 0 && i <= 1 );
-		m_nALPHATEXTURE = i;
-#ifdef _DEBUG
-		m_bALPHATEXTURE = true;
-#endif	// _DEBUG
-	}
-
 	teamcolorhud_ps20b_Static_Index(  )
 	{
 		m_nDISTANCEALPHAMODE = 0;
@@ -90,26 +79,23 @@ public:
 		m_nBLENDTINTBYXALPHA = 0;
 		m_nVERTEXRGB = 0;
 		m_nVERTEXA = 0;
-		m_nALPHATEXTURE = 0;
 #ifdef _DEBUG
 		m_bDISTANCEALPHAMODE = false;
 		m_bDETAILTEXTUREMODE = false;
 		m_bBLENDTINTBYXALPHA = false;
 		m_bVERTEXRGB = false;
 		m_bVERTEXA = false;
-		m_bALPHATEXTURE = false;
 #endif	// _DEBUG
 	}
 
 	int GetIndex() const
 	{
-		Assert( m_bDISTANCEALPHAMODE && m_bDETAILTEXTUREMODE && m_bBLENDTINTBYXALPHA && m_bVERTEXRGB && m_bVERTEXA && m_bALPHATEXTURE );
-		AssertMsg( !( ( m_nDISTANCEALPHAMODE >= 8 ) && ( ( m_nDETAILTEXTUREMODE == 0 ) || ( m_nALPHATEXTURE == 1 ) ) ), "Invalid combo combination ( ( DISTANCEALPHAMODE >= 8 ) && ( ( DETAILTEXTUREMODE == 0 ) || ( ALPHATEXTURE == 1 ) ) )" );
-		return ( 1 * m_nDISTANCEALPHAMODE ) + ( 15 * m_nDETAILTEXTUREMODE ) + ( 165 * m_nBLENDTINTBYXALPHA ) + ( 330 * m_nVERTEXRGB ) + ( 660 * m_nVERTEXA ) + ( 1320 * m_nALPHATEXTURE ) + 0;
+		Assert( m_bDISTANCEALPHAMODE && m_bDETAILTEXTUREMODE && m_bBLENDTINTBYXALPHA && m_bVERTEXRGB && m_bVERTEXA );
+		return ( 1 * m_nDISTANCEALPHAMODE ) + ( 15 * m_nDETAILTEXTUREMODE ) + ( 165 * m_nBLENDTINTBYXALPHA ) + ( 330 * m_nVERTEXRGB ) + ( 660 * m_nVERTEXA ) + 0;
 	}
 };
 
-#define shaderStaticTest_teamcolorhud_ps20b psh_forgot_to_set_static_DISTANCEALPHAMODE + psh_forgot_to_set_static_DETAILTEXTUREMODE + psh_forgot_to_set_static_BLENDTINTBYXALPHA + psh_forgot_to_set_static_VERTEXRGB + psh_forgot_to_set_static_VERTEXA + psh_forgot_to_set_static_ALPHATEXTURE
+#define shaderStaticTest_teamcolorhud_ps20b psh_forgot_to_set_static_DISTANCEALPHAMODE + psh_forgot_to_set_static_DETAILTEXTUREMODE + psh_forgot_to_set_static_BLENDTINTBYXALPHA + psh_forgot_to_set_static_VERTEXRGB + psh_forgot_to_set_static_VERTEXA
 
 
 class teamcolorhud_ps20b_Dynamic_Index

--- a/src/materialsystem/stdshaders/sdkshaders_dx9_20b.txt
+++ b/src/materialsystem/stdshaders/sdkshaders_dx9_20b.txt
@@ -14,3 +14,6 @@ sdk_bloom_ps2x.fxc
 sdk_screenspaceeffect_vs20.fxc
 
 sdk_bloomadd_ps2x.fxc
+
+teamcolorhud_vs20.fxc
+teamcolorhud_ps2x.fxc

--- a/src/materialsystem/stdshaders/teamcolorhud_ps2x.fxc
+++ b/src/materialsystem/stdshaders/teamcolorhud_ps2x.fxc
@@ -7,7 +7,6 @@
 // STATIC: "BLENDTINTBYXALPHA"			 "0..1"
 // STATIC: "VERTEXRGB"					"0..1"
 // STATIC: "VERTEXA"					"0..1"
-// STATIC: "ALPHATEXTURE"				"0..1"
 
 #define SRGB_INPUT_ADAPTER 0
 #define WRITEWATERFOGTODESTALPHA 0
@@ -17,6 +16,7 @@
 // dead stat: "DEPTHBLEND"				"0..1"
 // dead dyn: "WRITE_DEPTH_TO_DESTALPHA"	"0..1"
 // dead dyn: "PIXELFOGTYPE"				"0..2"
+// dead stat: "ALPHATEXTURE"			"0..1"
 
 // Consistent with previous Skips
 // Can still use Distance Alpha when sourcing from Detail Texture so account for that !!
@@ -142,7 +142,7 @@ const float4 g_DetailTintAndFactor	: register(c2);
 
 sampler BaseTextureSampler		: register( s0 );
 sampler DetailSampler			: register( s1 );
-sampler AlphaSampler			: register( s2 );
+sampler ColorSampler			: register( s2 );
 
 struct PS_INPUT
 {
@@ -173,6 +173,8 @@ const float4 g_OutlineColor : register( c8 );
 
 const float4 g_OutlineParams : register( c9 );
 // these are ordered this way for optimal ps20 swizzling
+const float4 g_RedColor				: register(c10);
+const float4 g_BlueColor			: register(c11);
 #define OUTLINE_MIN_VALUE0 g_OutlineParams.x
 #define OUTLINE_MAX_VALUE1 g_OutlineParams.y
 #define OUTLINE_MAX_VALUE0 g_OutlineParams.z
@@ -186,6 +188,7 @@ LPREVIEW_PS_OUT main( PS_INPUT i ) : COLOR
 float4 main( PS_INPUT i ) : COLOR
 #endif
 */
+#define white float3(1,1,1)
 
 float4 main( PS_INPUT i ) : COLOR
 {
@@ -195,22 +198,21 @@ float4 main( PS_INPUT i ) : COLOR
 		f4BaseTexture.rgb = GammaToLinear( f4BaseTexture.rgb );
 	#endif
 
-#if ALPHATEXTURE
-	// Red Channel ( First Channel ) of the $AlphaTexture
-	float4 AlphaTexture = tex2D(AlphaSampler, i.TexCoord0.xy);
-	float f1FinalAlpha = AlphaTexture.r;
-	float f1DistAlphaMask = AlphaTexture.r;
-
-#elif (DISTANCEALPHA && !DISTANCEALPHAFROMDETAIL)
+	// $ColorMask
+	float4 ColorMask = tex2D(ColorSampler, i.TexCoord0.xy);
+	float f1FinalAlpha = f4BaseTexture.a;
 	float f1DistAlphaMask = f4BaseTexture.a;
-#endif
+
+	f4BaseTexture.rgb *= ((white * (1 - ColorMask.r)) + (g_RedColor.rgb * ColorMask.r));
+	f4BaseTexture.rgb *= ((white * (1 - ColorMask.b)) + (g_BlueColor.rgb * ColorMask.b));
+
 
 #if DETAILTEXTURE
 	float4 f4DetailTexture = tex2D(DetailSampler, i.TexCoord0.zw);
 	f4DetailTexture.rgb *= g_DetailTint;
 	
 	#if (DISTANCEALPHA && DISTANCEALPHAFROMDETAIL)
-		float f1DistAlphaMask = f4DetailTexture.a;
+		f1DistAlphaMask = f4DetailTexture.a;
 		f4DetailTexture.a = 1.0; // make tcombine treat as 1.0
 	#endif
 
@@ -241,17 +243,12 @@ float4 main( PS_INPUT i ) : COLOR
 	#if SOFT_MASK
 		mskUsed = smoothstep( SOFT_MASK_MIN, SOFT_MASK_MAX, f1DistAlphaMask );
 
-		#if ALPHATEXTURE
-			f1FinalAlpha = mskUsed;
-		#else
-			f4BaseTexture.a *= mskUsed;
-		#endif
+		f1FinalAlpha = mskUsed;
+
 	#else
 		mskUsed = f1DistAlphaMask >= 0.5;
 
-		#if ALPHATEXTURE
-			f1FinalAlpha = mskUsed;
-		#elif DETAILTEXTURE
+		#if DETAILTEXTURE
 			f4BaseTexture.a *= mskUsed;
 		#else
 			f4BaseTexture.a = mskUsed;
@@ -279,9 +276,6 @@ float4 main( PS_INPUT i ) : COLOR
 		f4BaseTexture.rgb *= g_DiffuseModulation.rgb;
 	#endif
 
-	#if !ALPHATEXTURE
-		float f1FinalAlpha = f4BaseTexture.a;
-	#endif
 
 	// Nope
 //	f1FinalAlpha *= g_DiffuseModulation.w;


### PR DESCRIPTION
Changes the colorable hud shader to be dual colorable
* basetexture alpha controls transparency 
* $colormask controls colorable regions, red channel of the mask controls where the base will be colored by $redcolor and blue channel by $bluecolor

New proxies "TeamColorRed" and "TeamColorBlue", same as "TeamColor" but stuck to one specific team.
This is to reduce code workload on updating hud, existing vmts can be edited instead 